### PR TITLE
fix: override vim.o.winborder for completion floats 

### DIFF
--- a/lua/cursortab/ui.lua
+++ b/lua/cursortab/ui.lua
@@ -247,6 +247,7 @@ local function create_overlay_window(parent_win, buffer_line, col, content, synt
 		width = max_width,
 		height = #content_lines,
 		style = "minimal",
+		border = "none",
 		zindex = 1,
 		focusable = false,
 		-- Prevent Neovim from auto-adjusting window position when it doesn't fit
@@ -719,6 +720,7 @@ local function show_cursor_prediction(line_num)
 			width = text_width,
 			height = 1,
 			style = "minimal",
+			border = "none",
 			zindex = 1,
 			focusable = false,
 		})


### PR DESCRIPTION
Explicitly passes `border = "none"` for completion windows to override vim.o.winborder global option, because, arguably, borders never make sense for these ghost-text completions.
