### PR TITLE
feat: add metrics tracking for sweep provider

### DIFF
--- a/lua/cursortab/daemon.lua
+++ b/lua/cursortab/daemon.lua
@@ -49,12 +49,19 @@ local function start_daemon()
 		return false
 	end
 
+	-- Build editor info string for metrics/User-Agent (3-part format for amplitude parsing)
+	local v = vim.version()
+	local nvim_version = string.format("%d.%d.%d", v.major, v.minor, v.patch)
+	local os_name = vim.uv.os_uname().sysname
+	local editor_info = string.format("Neovim v%s - OS: %s - cursortab.nvim", nvim_version, os_name)
+
 	-- Create JSON configuration (matches Go Config struct)
 	-- Note: UI config is Lua-only (for highlights), not sent to Go daemon
 	local json_config = vim.json.encode({
 		ns_id = ns_id,
 		log_level = cfg.log_level,
 		state_dir = state_dir,
+		editor_info = editor_info,
 		behavior = {
 			idle_completion_delay = cfg.behavior.idle_completion_delay,
 			text_change_debounce = cfg.behavior.text_change_debounce,

--- a/server/engine/accept.go
+++ b/server/engine/accept.go
@@ -8,6 +8,7 @@ import (
 
 // reject clears all state and returns to idle.
 func (e *Engine) reject() {
+	e.trackDisposed()
 	e.clearState(ClearOptions{
 		CancelCurrent:     true,
 		CancelPrefetch:    true,
@@ -54,6 +55,8 @@ func (e *Engine) acceptCompletion() {
 	if accepter, ok := e.provider.(CompletionAccepter); ok {
 		go accepter.AcceptCompletion(e.mainCtx)
 	}
+
+	e.trackAccepted()
 
 	// 2. Clear completion state (keep prefetch)
 	e.clearCompletionState()
@@ -411,6 +414,7 @@ func (e *Engine) finalizePartialAccept() {
 		return
 	}
 
+	e.trackAccepted()
 	e.buffer.CommitPending()
 	e.saveCurrentFileState()
 	e.clearCompletionState()

--- a/server/engine/completion.go
+++ b/server/engine/completion.go
@@ -52,6 +52,7 @@ func (e *Engine) handleTextChangeImpl() {
 			return
 		}
 		// User typed everything - completion fully typed
+		e.trackAccepted()
 		e.clearAll()
 		e.state = stateIdle
 		e.startTextChangeTimer()
@@ -312,6 +313,8 @@ func (e *Engine) processCompletion(completion *types.Completion) bool {
 			CurrentIdx: 0,
 			SourcePath: e.buffer.Path(),
 		}
+
+		e.trackShown(len(completion.Lines), len(originalLines))
 
 		if stagingResult.FirstNeedsNavigation {
 			firstStage := stagingResult.Stages[0]

--- a/server/engine/events.go
+++ b/server/engine/events.go
@@ -464,6 +464,7 @@ func (e *Engine) doRejectStreamingAndDebounce(event Event) {
 				return
 			}
 			// User typed everything
+			e.trackAccepted()
 			e.clearAll()
 			e.state = stateIdle
 			e.startTextChangeTimer()
@@ -490,6 +491,7 @@ func (e *Engine) doRejectStreamingAndDebounce(event Event) {
 				return
 			}
 			// User typed everything
+			e.trackAccepted()
 			e.clearAll()
 			e.state = stateIdle
 			e.startTextChangeTimer()

--- a/server/engine/stream.go
+++ b/server/engine/stream.go
@@ -380,6 +380,8 @@ func (e *Engine) renderStreamedStage(stage *text.Stage) {
 
 	// Store groups for partial accept
 	e.currentGroups = stage.Groups
+
+	e.trackShown(len(stage.Lines), stage.BufferEnd-stage.BufferStart+1)
 }
 
 // handleTokenChunk processes a cumulative text chunk from token streaming.
@@ -431,6 +433,10 @@ func (e *Engine) handleTokenChunk(accumulatedText string) {
 
 	// Store groups for partial accept
 	e.currentGroups = []*text.Group{group}
+
+	if e.activeMetrics == nil {
+		e.trackShown(1, 1)
+	}
 }
 
 // handleTokenStreamComplete processes token stream completion when channel closes.

--- a/server/engine/types.go
+++ b/server/engine/types.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"cursortab/buffer"
+	"cursortab/metrics"
 	"cursortab/text"
 	"cursortab/types"
 )
@@ -206,4 +207,5 @@ type EngineConfig struct {
 	CursorPrediction    CursorPredictionConfig
 	MaxDiffTokens       int // Maximum tokens for diff history per file (0 = no limit)
 	MaxVisibleLines     int // Maximum lines per stage (0 = no limit)
+	MetricsTracker      *metrics.MetricsTracker
 }

--- a/server/main.go
+++ b/server/main.go
@@ -57,12 +57,13 @@ type DebugConfig struct {
 
 // Config is the main configuration structure
 type Config struct {
-	NsID     int            `json:"ns_id"`
-	LogLevel string         `json:"log_level"`
-	StateDir string         `json:"state_dir"`
-	Behavior BehaviorConfig `json:"behavior"`
-	Provider ProviderConfig `json:"provider"`
-	Debug    DebugConfig    `json:"debug"`
+	NsID       int            `json:"ns_id"`
+	LogLevel   string         `json:"log_level"`
+	StateDir   string         `json:"state_dir"`
+	EditorInfo string         `json:"editor_info"`
+	Behavior   BehaviorConfig `json:"behavior"`
+	Provider   ProviderConfig `json:"provider"`
+	Debug      DebugConfig    `json:"debug"`
 }
 
 // Validate checks that the config has valid values.

--- a/server/metrics/tracker.go
+++ b/server/metrics/tracker.go
@@ -1,0 +1,180 @@
+package metrics
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"cursortab/logger"
+)
+
+const metricsURL = "https://backend.app.sweep.dev/backend/track_autocomplete_metrics"
+
+const (
+	EventShown    = "autocomplete_suggestion_shown"
+	EventAccepted = "autocomplete_suggestion_accepted"
+	EventDisposed = "autocomplete_suggestion_disposed"
+)
+
+const (
+	SuggestionGhostText = "GHOST_TEXT"
+)
+
+type MetricsRequest struct {
+	EventType          string `json:"event_type"`
+	SuggestionType     string `json:"suggestion_type"`
+	Additions          int    `json:"additions"`
+	Deletions          int    `json:"deletions"`
+	AutocompleteID     string `json:"autocomplete_id"`
+	Lifespan           *int64 `json:"lifespan"`
+	DebugInfo          string `json:"debug_info"`
+	DeviceID           string `json:"device_id"`
+	PrivacyModeEnabled bool   `json:"privacy_mode_enabled"`
+}
+
+type CompletionMetrics struct {
+	ID        string
+	Additions int
+	Deletions int
+	ShownAt   time.Time
+}
+
+type MetricsTracker struct {
+	apiKey     string
+	editorInfo string
+	deviceID   string
+	httpClient *http.Client
+}
+
+func NewTracker(apiKey, editorInfo, dataDir string) *MetricsTracker {
+	deviceID := loadOrCreateDeviceID(dataDir)
+	return &MetricsTracker{
+		apiKey:     apiKey,
+		editorInfo: editorInfo,
+		deviceID:   deviceID,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func (t *MetricsTracker) TrackShown(m *CompletionMetrics) {
+	t.sendRequest(&MetricsRequest{
+		EventType:          EventShown,
+		SuggestionType:     SuggestionGhostText,
+		Additions:          m.Additions,
+		Deletions:          m.Deletions,
+		AutocompleteID:     m.ID,
+		Lifespan:           nil,
+		DebugInfo:          t.editorInfo,
+		DeviceID:           t.deviceID,
+		PrivacyModeEnabled: false,
+	})
+}
+
+func (t *MetricsTracker) TrackAccepted(m *CompletionMetrics) {
+	t.sendRequest(&MetricsRequest{
+		EventType:          EventAccepted,
+		SuggestionType:     SuggestionGhostText,
+		Additions:          m.Additions,
+		Deletions:          m.Deletions,
+		AutocompleteID:     m.ID,
+		Lifespan:           nil,
+		DebugInfo:          t.editorInfo,
+		DeviceID:           t.deviceID,
+		PrivacyModeEnabled: false,
+	})
+}
+
+func (t *MetricsTracker) TrackDisposed(m *CompletionMetrics) {
+	lifespan := time.Since(m.ShownAt).Milliseconds()
+	t.sendRequest(&MetricsRequest{
+		EventType:          EventDisposed,
+		SuggestionType:     SuggestionGhostText,
+		Additions:          m.Additions,
+		Deletions:          m.Deletions,
+		AutocompleteID:     m.ID,
+		Lifespan:           &lifespan,
+		DebugInfo:          t.editorInfo,
+		DeviceID:           t.deviceID,
+		PrivacyModeEnabled: false,
+	})
+}
+
+func (t *MetricsTracker) sendRequest(req *MetricsRequest) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
+		body, err := json.Marshal(req)
+		if err != nil {
+			logger.Debug("metrics: marshal error: %v", err)
+			return
+		}
+
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", metricsURL, bytes.NewReader(body))
+		if err != nil {
+			logger.Debug("metrics: create request error: %v", err)
+			return
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Authorization", "Bearer "+t.apiKey)
+
+		resp, err := t.httpClient.Do(httpReq)
+		if err != nil {
+			logger.Debug("metrics: send error: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		io.Copy(io.Discard, resp.Body)
+
+		if resp.StatusCode >= 400 {
+			logger.Debug("metrics: server returned %d for %s", resp.StatusCode, req.EventType)
+		} else {
+			logger.Debug("metrics: sent %s (id=%s)", req.EventType, req.AutocompleteID)
+		}
+	}()
+}
+
+func loadOrCreateDeviceID(dataDir string) string {
+	if dataDir == "" {
+		return GenerateUUID()
+	}
+
+	idPath := filepath.Join(dataDir, "device_id")
+
+	data, err := os.ReadFile(idPath)
+	if err == nil {
+		id := strings.TrimSpace(string(data))
+		if id != "" {
+			return id
+		}
+	}
+
+	id := GenerateUUID()
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		logger.Warn("metrics: could not create data dir %s: %v", dataDir, err)
+		return id
+	}
+	if err := os.WriteFile(idPath, []byte(id), 0644); err != nil {
+		logger.Warn("metrics: could not write device_id: %v", err)
+	}
+	return id
+}
+
+func GenerateUUID() string {
+	var uuid [16]byte
+	if _, err := rand.Read(uuid[:]); err != nil {
+		return fmt.Sprintf("fallback-%d", time.Now().UnixNano())
+	}
+	uuid[6] = (uuid[6] & 0x0f) | 0x40 // version 4
+	uuid[8] = (uuid[8] & 0x3f) | 0x80 // variant 2
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:16])
+}

--- a/server/provider/sweep/sweep_test.go
+++ b/server/provider/sweep/sweep_test.go
@@ -13,7 +13,7 @@ func TestBuildPrompt_EmptyLines(t *testing.T) {
 	config := &types.ProviderConfig{
 		ProviderModel: "test-model",
 	}
-	p := NewProvider(config)
+	p := NewProvider(config, "")
 
 	ctx := &provider.Context{
 		Request: &types.CompletionRequest{
@@ -34,7 +34,7 @@ func TestBuildPrompt_WithContent(t *testing.T) {
 	config := &types.ProviderConfig{
 		ProviderModel: "test-model",
 	}
-	p := NewProvider(config)
+	p := NewProvider(config, "")
 
 	ctx := &provider.Context{
 		Request: &types.CompletionRequest{
@@ -55,7 +55,7 @@ func TestBuildPrompt_WithDiffHistory(t *testing.T) {
 	config := &types.ProviderConfig{
 		ProviderModel: "test-model",
 	}
-	p := NewProvider(config)
+	p := NewProvider(config, "")
 
 	ctx := &provider.Context{
 		Request: &types.CompletionRequest{
@@ -150,7 +150,7 @@ func TestParseCompletion_NoChange(t *testing.T) {
 	config := &types.ProviderConfig{
 		ProviderModel: "test-model",
 	}
-	p := NewProvider(config)
+	p := NewProvider(config, "")
 
 	ctx := &provider.Context{
 		Request: &types.CompletionRequest{
@@ -173,7 +173,7 @@ func TestParseCompletion_WithChange(t *testing.T) {
 	config := &types.ProviderConfig{
 		ProviderModel: "test-model",
 	}
-	p := NewProvider(config)
+	p := NewProvider(config, "")
 
 	ctx := &provider.Context{
 		Request: &types.CompletionRequest{
@@ -197,7 +197,7 @@ func TestParseCompletion_StripsStopTokens(t *testing.T) {
 	config := &types.ProviderConfig{
 		ProviderModel: "test-model",
 	}
-	p := NewProvider(config)
+	p := NewProvider(config, "")
 
 	ctx := &provider.Context{
 		Request: &types.CompletionRequest{
@@ -220,7 +220,7 @@ func TestParseCompletion_InvalidWindow(t *testing.T) {
 	config := &types.ProviderConfig{
 		ProviderModel: "test-model",
 	}
-	p := NewProvider(config)
+	p := NewProvider(config, "")
 
 	ctx := &provider.Context{
 		Request: &types.CompletionRequest{


### PR DESCRIPTION
## Summary
- Track autocomplete shown/accepted/disposed events for the `sweep` provider, reporting to Sweep's metrics API (`/backend/track_autocomplete_metrics`)
- Send editor identification (`Neovim v{version} - OS: {os} - cursortab.nvim`) as User-Agent on sweep completion requests and as `debug_info` in metrics payloads (3-part format matching amplitude parser)
- Persistent device ID stored at `{state_dir}/device_id`

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./...` all tests pass
- [ ] Set provider type to `sweep` with a valid API key, trigger completions, check `cursortab.log` for metrics send logs
- [ ] Set provider type to `inline` — verify no metrics HTTP requests