### PR TITLE
fix(ui): add pcall to ensure_close_all

### DIFF
--- a/lua/cursortab/ui.lua
+++ b/lua/cursortab/ui.lua
@@ -921,7 +921,11 @@ end
 function ui.show_cursor_prediction(line_num)
 	has_cursor_prediction = true
 	ui.ensure_close_all()
-	show_cursor_prediction(line_num)
+	local ok = pcall(show_cursor_prediction, line_num)
+	if not ok then
+		ui.ensure_close_all()
+		has_cursor_prediction = false
+	end
 end
 
 -- Close all UI elements and reset state (for on_reject)


### PR DESCRIPTION
Issue:

Pressing Ctrl-C in between generations is causing broken overlay on the screen to stay on the screen and shows this log:
```
2026/03/07 00:54:07 [ERROR] error executing lua function: nvim:nvim_exec_lua exception: Error executing lua:
  ...ocal/share/nvim/lazy/cursortab.nvim/lua/cursortab/ui.lua:311: Keyboard interrupt
  stack traceback:
      [C]: in function 'nvim_open_win'
      ...ocal/share/nvim/lazy/cursortab.nvim/lua/cursortab/ui.lua:311: in function 'create_overlay_window'
      ...ocal/share/nvim/lazy/cursortab.nvim/lua/cursortab/ui.lua:647: in function 'render_modification'
      ...ocal/share/nvim/lazy/cursortab.nvim/lua/cursortab/ui.lua:776: in function 'show_completion'
      ...ocal/share/nvim/lazy/cursortab.nvim/lua/cursortab/ui.lua:912: in function 'show_completion'
      ...al/share/nvim/lazy/cursortab.nvim/lua/cursortab/init.lua:32: in function 'on_completion_ready'
      [string "<nvim>"]:1: in main chunk
```
