### PR TITLE
feat: add Windows support via platform-specific IPC

### DIFF
--- a/lua/cursortab/daemon.lua
+++ b/lua/cursortab/daemon.lua
@@ -12,10 +12,25 @@ local ns_id = vim.api.nvim_create_namespace("cursortab")
 local event_debounce_timer = nil
 local is_enabled = true
 
+local is_windows = vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1
+
+local function get_ipc_path(state_dir)
+	if is_windows then
+		return state_dir .. "/cursortab.port"
+	else
+		return state_dir .. "/cursortab.sock"
+	end
+end
+
 -- Check if process with given PID is running
 local function is_process_running(pid)
-	vim.fn.system("kill -0 " .. pid .. " 2>/dev/null")
-	return vim.v.shell_error == 0
+	if is_windows then
+		vim.fn.system('tasklist /FI "PID eq ' .. pid .. '" 2>NUL | findstr /I "' .. pid .. '"')
+		return vim.v.shell_error == 0
+	else
+		vim.fn.system("kill -0 " .. pid .. " 2>/dev/null")
+		return vim.v.shell_error == 0
+	end
 end
 
 -- Read daemon PID from file and check if it's running
@@ -50,7 +65,7 @@ local function start_daemon()
 		binary_name = binary_name .. ".exe"
 	end
 	local binary_path = plugin_dir .. "/server/" .. binary_name
-	local socket_path = state_dir .. "/cursortab.sock"
+	local ipc_path = get_ipc_path(state_dir)
 	local pid_path = state_dir .. "/cursortab.pid"
 
 	-- Check if binary exists
@@ -117,7 +132,7 @@ local function start_daemon()
 	local need_daemon_start = false
 	local config_path = state_dir .. "/cursortab.config.json"
 
-	if vim.fn.filereadable(socket_path) == 0 then
+	if vim.fn.filereadable(ipc_path) == 0 then
 		-- No socket, need to start daemon
 		need_daemon_start = true
 	else
@@ -126,7 +141,7 @@ local function start_daemon()
 
 		if not daemon_running then
 			-- Stale socket, clean up and start fresh
-			vim.fn.delete(socket_path)
+			vim.fn.delete(ipc_path)
 			if vim.fn.filereadable(pid_path) == 1 then
 				vim.fn.delete(pid_path)
 			end
@@ -153,7 +168,7 @@ local function start_daemon()
 		-- Wait for socket (max 1 second)
 		for _ = 1, 10 do
 			vim.wait(100)
-			if vim.fn.filereadable(socket_path) == 1 then
+			if vim.fn.filereadable(ipc_path) == 1 then
 				break
 			end
 		end
@@ -237,11 +252,11 @@ end
 function daemon.check_daemon_status()
 	local cfg = config.get()
 	local state_dir = cfg.state_dir
-	local socket_path = state_dir .. "/cursortab.sock"
+	local ipc_path = get_ipc_path(state_dir)
 	local pid_path = state_dir .. "/cursortab.pid"
 
 	local status = {
-		socket_exists = vim.fn.filereadable(socket_path) == 1,
+		socket_exists = vim.fn.filereadable(ipc_path) == 1,
 		pid_file_exists = vim.fn.filereadable(pid_path) == 1,
 		daemon_running = false,
 		pid = nil,
@@ -269,13 +284,13 @@ end
 local function cleanup_stale_files()
 	local cfg = config.get()
 	local state_dir = cfg.state_dir
-	local socket_path = state_dir .. "/cursortab.sock"
+	local ipc_path = get_ipc_path(state_dir)
 	local pid_path = state_dir .. "/cursortab.pid"
 	local config_path = state_dir .. "/cursortab.config.json"
 
-	-- Remove socket file if it exists
-	if vim.fn.filereadable(socket_path) == 1 then
-		vim.fn.delete(socket_path)
+	-- Remove IPC file if it exists
+	if vim.fn.filereadable(ipc_path) == 1 then
+		vim.fn.delete(ipc_path)
 	end
 
 	-- Remove pid file if it exists
@@ -294,16 +309,16 @@ function daemon.stop_daemon()
 	local cfg = config.get()
 	local state_dir = cfg.state_dir
 	local pid_path = state_dir .. "/cursortab.pid"
-	local socket_path = state_dir .. "/cursortab.sock"
+	local ipc_path = get_ipc_path(state_dir)
 
 	-- Reset channel regardless of outcome
 	chan = nil
 
-	-- If no PID file, just clean up any stale socket
+	-- If no PID file, just clean up any stale IPC
 	if vim.fn.filereadable(pid_path) == 0 then
-		if vim.fn.filereadable(socket_path) == 1 then
-			vim.fn.delete(socket_path)
-			return true, "Cleaned up stale socket (no PID file)"
+		if vim.fn.filereadable(ipc_path) == 1 then
+			vim.fn.delete(ipc_path)
+			return true, "Cleaned up stale IPC (no PID file)"
 		end
 		return true, "Daemon not running (no PID file)"
 	end
@@ -320,25 +335,35 @@ function daemon.stop_daemon()
 	end
 
 	-- Send TERM signal to daemon
-	vim.fn.system("kill " .. pid .. " 2>/dev/null")
-	local kill_sent = vim.v.shell_error == 0
+	local kill_sent
+	if is_windows then
+		vim.fn.system('taskkill /PID ' .. pid)
+		kill_sent = vim.v.shell_error == 0
+	else
+		vim.fn.system("kill " .. pid .. " 2>/dev/null")
+		kill_sent = vim.v.shell_error == 0
+	end
 
 	if not kill_sent then
 		cleanup_stale_files()
 		return true, "Cleaned up stale files (could not signal process)"
 	end
 
-	-- Wait for socket to be removed (daemon cleanup)
+	-- Wait for IPC to be removed (daemon cleanup)
 	for _ = 1, 50 do
 		vim.wait(100)
-		if vim.fn.filereadable(socket_path) == 0 then
+		if vim.fn.filereadable(ipc_path) == 0 then
 			return true, "Daemon stopped successfully"
 		end
 	end
 
-	-- Process didn't terminate gracefully, send SIGKILL
+	-- Process didn't terminate gracefully, force kill
 	if is_process_running(pid) then
-		vim.fn.system("kill -9 " .. pid .. " 2>/dev/null")
+		if is_windows then
+			vim.fn.system('taskkill /F /PID ' .. pid)
+		else
+			vim.fn.system("kill -9 " .. pid .. " 2>/dev/null")
+		end
 		-- Brief wait for forced termination
 		vim.wait(100)
 	end

--- a/server/client.go
+++ b/server/client.go
@@ -4,24 +4,22 @@ import (
 	"cursortab/logger"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"time"
 )
 
 type Client struct {
-	socketPath string
+	stateDir string
 }
 
 func NewClient(stateDir string) *Client {
 	return &Client{
-		socketPath: getSocketPath(stateDir),
+		stateDir: stateDir,
 	}
 }
 
 func (c *Client) Connect() error {
-	// Connect to daemon
-	conn, err := net.Dial("unix", c.socketPath)
+	conn, err := dialIPC(c.stateDir)
 	if err != nil {
 		return err
 	}

--- a/server/daemon.go
+++ b/server/daemon.go
@@ -135,14 +135,14 @@ func NewDaemon(config Config) (*Daemon, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Daemon{
-		config:     config,
-		provider:   prov,
-		buffer:     buf,
-		engine:     eng,
-		pidPath:    getPidPath(config.StateDir),
-		shutdown:   make(chan bool, 1),
-		ctx:        ctx,
-		cancel:     cancel,
+		config:   config,
+		provider: prov,
+		buffer:   buf,
+		engine:   eng,
+		pidPath:  getPidPath(config.StateDir),
+		shutdown: make(chan bool, 1),
+		ctx:      ctx,
+		cancel:   cancel,
 	}, nil
 }
 

--- a/server/daemon.go
+++ b/server/daemon.go
@@ -6,10 +6,8 @@ import (
 	"io"
 	"net"
 	"os"
-	"os/signal"
 	"strconv"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"cursortab/buffer"
@@ -36,7 +34,6 @@ type Daemon struct {
 	buffer      *buffer.NvimBuffer
 	engine      *engine.Engine
 	listener    net.Listener
-	socketPath  string
 	pidPath     string
 	clientCount int64
 	shutdown    chan bool
@@ -142,7 +139,6 @@ func NewDaemon(config Config) (*Daemon, error) {
 		provider:   prov,
 		buffer:     buf,
 		engine:     eng,
-		socketPath: getSocketPath(config.StateDir),
 		pidPath:    getPidPath(config.StateDir),
 		shutdown:   make(chan bool, 1),
 		ctx:        ctx,
@@ -155,13 +151,15 @@ func (d *Daemon) Start() error {
 	d.writePidFile()
 	defer d.removePidFile()
 
-	// Setup socket
-	if err := d.setupSocket(); err != nil {
+	// Setup IPC
+	listener, err := listenIPC(d.config.StateDir)
+	if err != nil {
 		return err
 	}
-	defer d.cleanup()
+	d.listener = listener
+	defer cleanupIPC(d.config.StateDir)
 
-	logger.Info("daemon listening on socket: %s", d.socketPath)
+	logger.Info("daemon listening on: %s", getIPCAddress(d.config.StateDir))
 
 	// Start engine
 	d.engine.Start(d.ctx)
@@ -181,27 +179,11 @@ func (d *Daemon) Start() error {
 	return nil
 }
 
-func (d *Daemon) setupSocket() error {
-	// Remove existing socket
-	os.Remove(d.socketPath)
-
-	// Listen on Unix socket
-	listener, err := net.Listen("unix", d.socketPath)
-	if err != nil {
-		return err
-	}
-	d.listener = listener
-	return nil
-}
-
 func (d *Daemon) setupShutdownHandling() {
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-sigChan
+	setupShutdownHandler(func() {
 		logger.Info("received shutdown signal")
 		d.Stop()
-	}()
+	})
 }
 
 func (d *Daemon) acceptConnections() {
@@ -303,10 +285,6 @@ func (d *Daemon) Stop() {
 		d.listener.Close()
 	}
 	d.cancel()
-}
-
-func (d *Daemon) cleanup() {
-	os.Remove(d.socketPath)
 }
 
 func (d *Daemon) writePidFile() {

--- a/server/daemon.go
+++ b/server/daemon.go
@@ -152,14 +152,14 @@ func (d *Daemon) Start() error {
 	defer d.removePidFile()
 
 	// Setup IPC
-	listener, err := listenIPC(d.config.StateDir)
+	listener, addr, err := listenIPC(d.config.StateDir)
 	if err != nil {
 		return err
 	}
 	d.listener = listener
 	defer cleanupIPC(d.config.StateDir)
 
-	logger.Info("daemon listening on: %s", getIPCAddress(d.config.StateDir))
+	logger.Info("daemon listening on: %s", addr)
 
 	// Start engine
 	d.engine.Start(d.ctx)

--- a/server/daemon.go
+++ b/server/daemon.go
@@ -281,10 +281,10 @@ func (d *Daemon) monitorIdleShutdown() {
 
 func (d *Daemon) Stop() {
 	d.engine.Stop()
+	d.cancel()
 	if d.listener != nil {
 		d.listener.Close()
 	}
-	d.cancel()
 }
 
 func (d *Daemon) writePidFile() {

--- a/server/ipc_unix.go
+++ b/server/ipc_unix.go
@@ -14,10 +14,11 @@ func getIPCAddress(stateDir string) string {
 	return filepath.Join(stateDir, "cursortab.sock")
 }
 
-func listenIPC(stateDir string) (net.Listener, error) {
+func listenIPC(stateDir string) (net.Listener, string, error) {
 	path := getIPCAddress(stateDir)
 	os.Remove(path)
-	return net.Listen("unix", path)
+	l, err := net.Listen("unix", path)
+	return l, path, err
 }
 
 func dialIPC(stateDir string) (net.Conn, error) {

--- a/server/ipc_unix.go
+++ b/server/ipc_unix.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package main
+
+import (
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+)
+
+func getIPCAddress(stateDir string) string {
+	return filepath.Join(stateDir, "cursortab.sock")
+}
+
+func listenIPC(stateDir string) (net.Listener, error) {
+	path := getIPCAddress(stateDir)
+	os.Remove(path)
+	return net.Listen("unix", path)
+}
+
+func dialIPC(stateDir string) (net.Conn, error) {
+	return net.Dial("unix", getIPCAddress(stateDir))
+}
+
+func cleanupIPC(stateDir string) {
+	os.Remove(getIPCAddress(stateDir))
+}
+
+func isProcessRunning(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}
+
+func setupShutdownHandler(onShutdown func()) {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		onShutdown()
+	}()
+}

--- a/server/ipc_windows.go
+++ b/server/ipc_windows.go
@@ -16,15 +16,15 @@ func getIPCAddress(stateDir string) string {
 	return filepath.Join(stateDir, "cursortab.port")
 }
 
-func listenIPC(stateDir string) (net.Listener, error) {
+func listenIPC(stateDir string) (net.Listener, string, error) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	port := l.Addr().(*net.TCPAddr).Port
+	addr := fmt.Sprintf("127.0.0.1:%d", l.Addr().(*net.TCPAddr).Port)
 	portPath := getIPCAddress(stateDir)
-	os.WriteFile(portPath, []byte(strconv.Itoa(port)), 0644)
-	return l, nil
+	os.WriteFile(portPath, []byte(strconv.Itoa(l.Addr().(*net.TCPAddr).Port)), 0644)
+	return l, addr, nil
 }
 
 func dialIPC(stateDir string) (net.Conn, error) {

--- a/server/ipc_windows.go
+++ b/server/ipc_windows.go
@@ -21,10 +21,12 @@ func listenIPC(stateDir string) (net.Listener, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	addr := fmt.Sprintf("127.0.0.1:%d", l.Addr().(*net.TCPAddr).Port)
-	portPath := getIPCAddress(stateDir)
-	os.WriteFile(portPath, []byte(strconv.Itoa(l.Addr().(*net.TCPAddr).Port)), 0644)
-	return l, addr, nil
+	port := l.Addr().(*net.TCPAddr).Port
+	if err := os.WriteFile(getIPCAddress(stateDir), []byte(strconv.Itoa(port)), 0644); err != nil {
+		l.Close()
+		return nil, "", err
+	}
+	return l, fmt.Sprintf("127.0.0.1:%d", port), nil
 }
 
 func dialIPC(stateDir string) (net.Conn, error) {

--- a/server/ipc_windows.go
+++ b/server/ipc_windows.go
@@ -1,0 +1,70 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+func getIPCAddress(stateDir string) string {
+	return filepath.Join(stateDir, "cursortab.port")
+}
+
+func listenIPC(stateDir string) (net.Listener, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	portPath := getIPCAddress(stateDir)
+	os.WriteFile(portPath, []byte(strconv.Itoa(port)), 0644)
+	return l, nil
+}
+
+func dialIPC(stateDir string) (net.Conn, error) {
+	portPath := getIPCAddress(stateDir)
+	data, err := os.ReadFile(portPath)
+	if err != nil {
+		return nil, err
+	}
+	port, err := strconv.Atoi(string(data))
+	if err != nil {
+		return nil, err
+	}
+	return net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+}
+
+func cleanupIPC(stateDir string) {
+	os.Remove(getIPCAddress(stateDir))
+}
+
+func isProcessRunning(pid int) bool {
+	const processQueryInformation = 0x0400
+	h, err := syscall.OpenProcess(processQueryInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer syscall.CloseHandle(h)
+
+	var exitCode uint32
+	err = syscall.GetExitCodeProcess(h, &exitCode)
+	if err != nil {
+		return false
+	}
+	return exitCode == 259 // STILL_ACTIVE
+}
+
+func setupShutdownHandler(onShutdown func()) {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	go func() {
+		<-sigChan
+		onShutdown()
+	}()
+}

--- a/server/logger/logger.go
+++ b/server/logger/logger.go
@@ -90,6 +90,7 @@ type LimitedLogger struct {
 	file      *os.File
 	lineCount int
 	level     LogLevel
+	pid       int
 	mutex     sync.Mutex
 }
 
@@ -102,6 +103,7 @@ func NewLimitedLogger(file *os.File, level LogLevel) *LimitedLogger {
 		file:      file,
 		lineCount: 0,
 		level:     level,
+		pid:       os.Getpid(),
 	}
 
 	// Count existing lines in the file
@@ -121,7 +123,7 @@ func (ll *LimitedLogger) logWithLevel(level LogLevel, format string, v ...any) {
 		return
 	}
 	// Format with timestamp and write through Write() for proper line counting/rotation
-	msg := fmt.Sprintf("%s [%s] %s\n", time.Now().Format("2006/01/02 15:04:05"), level.String(), fmt.Sprintf(format, v...))
+	msg := fmt.Sprintf("%s [%s] [PID %d] %s\n", time.Now().Format("2006/01/02 15:04:05"), level.String(), ll.pid, fmt.Sprintf(format, v...))
 	ll.Write([]byte(msg))
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 // CursorPredictionConfig holds cursor prediction settings
@@ -164,10 +163,6 @@ func setupLogger(stateDir, logLevel string) *logger.LimitedLogger {
 	return logger.NewLimitedLogger(f, level)
 }
 
-func getSocketPath(stateDir string) string {
-	return filepath.Join(stateDir, "cursortab.sock")
-}
-
 func getPidPath(stateDir string) string {
 	return filepath.Join(stateDir, "cursortab.pid")
 }
@@ -184,15 +179,8 @@ func isDaemonRunning(stateDir string) (bool, int) {
 		return false, 0
 	}
 
-	// Check if process is still running
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return false, 0
-	}
-
-	// On Unix, Signal(0) checks if process exists
-	err = process.Signal(syscall.Signal(0))
-	return err == nil, pid
+	running := isProcessRunning(pid)
+	return running, pid
 }
 
 // loadConfig parses config from CURSORTAB_CONFIG env var.


### PR DESCRIPTION
## Summary

Closes #80

This PR adds Windows support to cursortab.nvim. The Go daemon previously hardcoded Unix domain sockets and Unix signal handling, which do not work on Windows. This PR replaces those with platform-specific abstractions.

### Changes

- **`server/ipc_unix.go`** — Unix domain socket IPC: `net.Listen("unix", ...)`, `kill -0` process check, SIGTERM signal handling (unchanged behavior, extracted from existing code)
- **`server/ipc_windows.go`** — Windows TCP IPC: `net.Listen("tcp", "127.0.0.1:0")` with port file, `syscall.OpenProcess`/`GetExitCodeProcess` process check
- **`server/daemon.go`** — Refactored to use platform `listenIPC`/`cleanupIPC`/`setupShutdownHandler` instead of direct Unix socket/signal calls
- **`server/client.go`** — Refactored to use `dialIPC` instead of direct `net.Dial("unix", ...)`
- **`server/main.go`** — Removed `syscall` dependency, `isDaemonRunning` uses cross-platform `isProcessRunning`
- **`lua/cursortab/daemon.lua`** — Windows process management via `tasklist`/`taskkill`, platform-aware IPC path detection
- **`server/logger/logger.go`** — Added PID prefix to log entries for multi-instance debugging

### Testing

Verified on Windows 11 with Neovim 0.10+. The daemon starts, client connects, completions display, and daemon shuts down cleanly on idle timeout.