### PR TITLE
fix(ui): offset overlay row by winbar height

### DIFF
--- a/lua/cursortab/ui.lua
+++ b/lua/cursortab/ui.lua
@@ -336,11 +336,11 @@ local function create_overlay_window(parent_win, buffer_line, col, content, synt
 	local content_lines = type(content) == "table" and content or { content }
 
 	-- Query parent window state once: topline, leftcol, winrow, cursor, cursorline
-	---@type {topline: integer, leftcol: integer, winrow: integer, wincol: integer, textoff: integer}
+	---@type {topline: integer, leftcol: integer, winrow: integer, wincol: integer, textoff: integer, winbar: integer}
 	local wininfo = vim.fn.getwininfo(parent_win)[1]
 	local leftcol = wininfo.leftcol or 0
 	local first_visible_line = wininfo.topline
-	local winrow = wininfo.winrow or 1
+	local winrow = (wininfo.winrow or 1) + (wininfo.winbar or 0)
 	local cursor_line = vim.api.nvim_win_get_cursor(parent_win)[1] - 1
 	local cursorline_enabled = vim.api.nvim_get_option_value("cursorline", { win = parent_win })
 


### PR DESCRIPTION
I use Neovim winbar, floats with relative="win" origin row 0 below the winbar, but winrow `fromgetwininfo()` includes it, so overlays rendered one row too low when a winbar was active (current-line ghost text showed below the cursor). Added the winbar height so both reference the same row.

Before
<img width="474" height="170" alt="file-f81be9f7c061ece37d42d15f68712175" src="https://github.com/user-attachments/assets/7b6cb038-37fc-404d-8052-fc4884b00b69" />

After
<img width="467" height="166" alt="image" src="https://github.com/user-attachments/assets/060cc2ab-6026-4e53-9eee-979b07893d3e" />

