### PR TITLE
feat: add Zeta 2.1 prompt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Neovim plugin that provides edit completions and cursor predictions.
 * [Requirements](#requirements)
 * [Installation](#installation)
   * [Mercury API (hosted, no local GPU needed)](#mercury-api-hosted-no-local-gpu-needed)
-  * [Zeta-2 (local next-edit prediction)](#zeta-2-local-next-edit-prediction)
+  * [Zeta-2.1 (local next-edit prediction)](#zeta-21-local-next-edit-prediction)
   * [Qwen3.5-0.8B/Sweep (fastest local)](#qwen35-08bsweep-fastest-local)
   * [Using lazy.nvim](#using-lazynvim)
   * [Using packer.nvim](#using-packernvim)
@@ -29,6 +29,7 @@ A Neovim plugin that provides edit completions and cursor predictions.
     * [Inline Provider (Default)](#inline-provider-default)
     * [FIM Provider](#fim-provider)
     * [Sweep Provider](#sweep-provider)
+    * [Zeta-2.1 Provider](#zeta-21-provider)
     * [Zeta-2 Provider](#zeta-2-provider)
     * [Zeta Provider (legacy)](#zeta-provider-legacy)
     * [Copilot Provider](#copilot-provider)
@@ -54,7 +55,7 @@ A Neovim plugin that provides edit completions and cursor predictions.
 Recommended starting points:
 
 - **Best hosted:** Mercury API
-- **Best local next-edit:** Zeta-2
+- **Best local next-edit:** Zeta-2.1
 - **Fastest local:** Qwen3.5-0.8B with the `inline` provider, or Sweep 1.5B/0.5B
   with the `sweep` provider
 
@@ -70,12 +71,12 @@ config. See [Providers](#providers) for all available options.
    export MERCURY_AI_TOKEN="your-api-key-here"
    ```
 
-### Zeta-2 (local next-edit prediction)
+### Zeta-2.1 (local next-edit prediction)
 
 Run [llama.cpp](https://github.com/ggml-org/llama.cpp):
 
 ```bash
-llama-server -hf bartowski/zed-industries_zeta-2-GGUF:Q8_0 --port 8000
+llama-server -hf mradermacher/zeta-2.1-GGUF --ctx-size 16384 --port 8000
 ```
 
 ### Qwen3.5-0.8B/Sweep (fastest local)
@@ -103,8 +104,8 @@ llama-server -hf unsloth/Qwen3.5-0.8B-GGUF:Q8_0 --port 8000
         type = "mercuryapi",
         api_key_env = "MERCURY_AI_TOKEN",
 
-        -- Zeta-2 (best local)
-        -- type = "zeta-2",
+        -- Zeta-2.1 (best local)
+        -- type = "zeta-2.1",
         -- url = "http://localhost:8000",
 
         -- Qwen3.5-0.8B (fastest local, defaults to "inline")
@@ -202,7 +203,7 @@ require("cursortab").setup({
   },
 
   provider = {
-    type = "inline",                      -- Provider: "inline", "fim", "sweep", "zeta-2", "zeta", "copilot", "windsurf", or "mercuryapi"
+    type = "inline",                      -- Provider: "inline", "fim", "sweep", "zeta-2.1", "zeta-2", "zeta", "copilot", "windsurf", or "mercuryapi"
     url = "http://localhost:8000",        -- URL of the provider server
     api_key_env = "",                     -- Env var name for API key (e.g., "OPENAI_API_KEY")
     model = "",                           -- Model name
@@ -262,32 +263,33 @@ vim.api.nvim_set_hl(0, "CursorTabAddition", { bg = "#1a3a1a" })
 
 ### Providers
 
-The plugin supports eight AI provider backends: Inline, FIM, Sweep, Zeta-2, Zeta
-(legacy), Copilot, Windsurf, and Mercury API.
+The plugin supports nine AI provider backends: Inline, FIM, Sweep, Zeta-2.1,
+Zeta-2, Zeta (legacy), Copilot, Windsurf, and Mercury API.
 
-| Provider     | Hosted | Multi-line | Multi-edit | Cursor Prediction | Streaming | Model                   |
-| ------------ | :----: | :--------: | :--------: | :---------------: | :-------: | ----------------------- |
-| `inline`     |        |            |            |                   |           | Any base model          |
-| `fim`        |        |     ✓      |            |                   |     ✓     | Any FIM-capable         |
-| `sweep`      |        |     ✓      |     ✓      |         ✓         |     ✓     | Sweep Next-Edit family  |
-| `zeta-2`     |        |     ✓      |     ✓      |         ✓         |     ✓     | `zeta-2` (SeedCoder-8B) |
-| `zeta`       |        |     ✓      |     ✓      |         ✓         |     ✓     | `zeta` (Qwen2.5-Coder)  |
-| `copilot`    |   ✓    |     ✓      |     ✓      |         ✓         |           | GitHub Copilot          |
-| `windsurf`   |   ✓    |     ✓      |            |                   |           | Windsurf AI             |
-| `mercuryapi` |   ✓    |     ✓      |     ✓      |         ✓         |           | `mercury-edit-2`        |
+| Provider     | Hosted | Multi-line | Multi-edit | Cursor Prediction | Streaming | Model                     |
+| ------------ | :----: | :--------: | :--------: | :---------------: | :-------: | ------------------------- |
+| `inline`     |        |            |            |                   |           | Any base model            |
+| `fim`        |        |     ✓      |            |                   |     ✓     | Any FIM-capable           |
+| `sweep`      |        |     ✓      |     ✓      |         ✓         |     ✓     | Sweep Next-Edit family    |
+| `zeta-2.1`   |        |     ✓      |     ✓      |         ✓         |           | `zeta-2.1` (SeedCoder-8B) |
+| `zeta-2`     |        |     ✓      |     ✓      |         ✓         |     ✓     | `zeta-2` (SeedCoder-8B)   |
+| `zeta`       |        |     ✓      |     ✓      |         ✓         |     ✓     | `zeta` (Qwen2.5-Coder)    |
+| `copilot`    |   ✓    |     ✓      |     ✓      |         ✓         |           | GitHub Copilot            |
+| `windsurf`   |   ✓    |     ✓      |            |                   |           | Windsurf AI               |
+| `mercuryapi` |   ✓    |     ✓      |     ✓      |         ✓         |           | `mercury-edit-2`          |
 
 **Context Per Provider:**
 
-| Context             | inline | fim | sweep | zeta-2 | zeta | copilot | windsurf | mercuryapi |
-| ------------------- | :----: | :-: | :---: | :----: | :--: | :-----: | :------: | :--------: |
-| Buffer content      |   ✓    |  ✓  |   ✓   |   ✓    |  ✓   |         |    ✓     |     ✓      |
-| Edit history        |        | ✓°  |   ✓   |   ✓    |  ✓   |         |          |     ✓      |
-| Previous file state |        |     |   ✓   |        |      |         |          |            |
-| LSP diagnostics     |        | ✓°  |   ✓   |   ✓    |  ✓   |         |          |     ✓      |
-| Treesitter context  |        | ✓°  |   ✓   |   ✓    |  ✓   |         |          |     ✓      |
-| Git diff context    |        | ✓°  |   ✓   |   ✓    |  ✓   |         |          |     ✓      |
-| Recent files        |        | ✓°  |   ✓   |   ✓    |  ✓   |         |          |     ✓      |
-| User actions        |        |     |   ✓   |        |      |         |          |            |
+| Context             | inline | fim | sweep | zeta-2.1 | zeta-2 | zeta | copilot | windsurf | mercuryapi |
+| ------------------- | :----: | :-: | :---: | :------: | :----: | :--: | :-----: | :------: | :--------: |
+| Buffer content      |   ✓    |  ✓  |   ✓   |    ✓     |   ✓    |  ✓   |         |    ✓     |     ✓      |
+| Edit history        |        | ✓°  |   ✓   |    ✓     |   ✓    |  ✓   |         |          |     ✓      |
+| Previous file state |        |     |   ✓   |          |        |      |         |          |            |
+| LSP diagnostics     |        | ✓°  |   ✓   |    ✓     |   ✓    |  ✓   |         |          |     ✓      |
+| Treesitter context  |        | ✓°  |   ✓   |    ✓     |   ✓    |  ✓   |         |          |     ✓      |
+| Git diff context    |        | ✓°  |   ✓   |    ✓     |   ✓    |  ✓   |         |          |     ✓      |
+| Recent files        |        | ✓°  |   ✓   |    ✓     |   ✓    |  ✓   |         |          |     ✓      |
+| User actions        |        |     |   ✓   |          |        |      |         |          |            |
 
 ° FIM cross-file context requires repo-level tokens (`repo_name`, `file_sep`).
 Auto-detected for Qwen models; set manually for other models that support them.
@@ -394,13 +396,41 @@ llama-server -hf sweepai/sweep-next-edit-1.5b --port 8000
 
 </details>
 
+#### Zeta-2.1 Provider
+
+<details>
+<summary>Details</summary>
+
+Zed's [Zeta-2.1](https://huggingface.co/zed-industries/zeta-2.1)
+(SeedCoder-8B) uses the V0318 multi-region prompt. The model selects the exact
+rewrite span through numbered boundaries, reducing generated output compared
+with Zeta-2. Diagnostics are limited to ranged entries that intersect the
+editable excerpt. Run it locally with
+[llama.cpp](https://github.com/ggml-org/llama.cpp).
+
+```lua
+require("cursortab").setup({
+  provider = {
+    type = "zeta-2.1",
+    url = "http://localhost:8000",
+  },
+})
+```
+
+```bash
+llama-server -hf mradermacher/zeta-2.1-GGUF --ctx-size 16384 --port 8000
+```
+
+</details>
+
 #### Zeta-2 Provider
 
 <details>
 <summary>Details</summary>
 
-Zed's [Zeta-2](https://huggingface.co/zed-industries/zeta-2) (SeedCoder-8B). Run
-it locally with [llama.cpp](https://github.com/ggml-org/llama.cpp).
+Zed's [Zeta-2](https://huggingface.co/zed-industries/zeta-2) (SeedCoder-8B)
+uses the earlier single-region prompt. Run it locally with
+[llama.cpp](https://github.com/ggml-org/llama.cpp).
 
 ```lua
 require("cursortab").setup({
@@ -423,7 +453,7 @@ llama-server -hf bartowski/zed-industries_zeta-2-GGUF:Q8_0 --port 8000
 <summary>Details</summary>
 
 Zed's original [Zeta](https://huggingface.co/zed-industries/zeta) model
-(Qwen2.5-Coder-7B). Superseded by [Zeta-2](#zeta-2-provider).
+(Qwen2.5-Coder-7B). Superseded by [Zeta-2.1](#zeta-21-provider).
 
 ```lua
 require("cursortab").setup({

--- a/doc/cursortab.txt
+++ b/doc/cursortab.txt
@@ -102,7 +102,7 @@ Full configuration with defaults: >lua
     },
 
     provider = {
-      type = "inline",              -- "inline", "fim", "sweep", "zeta-2", "zeta", "copilot", "windsurf", "mercuryapi"
+      type = "inline",              -- "inline", "fim", "sweep", "zeta-2.1", "zeta-2", "zeta", "copilot", "windsurf", "mercuryapi"
       url = "http://localhost:8000",
       api_key_env = "",             -- Env var name for API key
       model = "",
@@ -281,10 +281,12 @@ behavior.ignore_gitignored      *cursortab-config-behavior-ignore-gitignored*
 PROVIDER OPTIONS                                    *cursortab-config-provider*
 
   `type`
-      Provider type: "inline", "fim", "sweep", "zeta-2", "zeta", "copilot", "windsurf", or "mercuryapi".
+      Provider type: "inline", "fim", "sweep", "zeta-2.1", "zeta-2", "zeta", "copilot", "windsurf", or "mercuryapi".
       - inline: End-of-line completion, stops at newline
       - fim: Fill-in-the-middle, multi-line with prefix/suffix context
       - sweep: SweepAI Next-Edit model for multi-line edits (local)
+      - zeta-2.1: Zed's Zeta-2.1 model (SeedCoder-8B, multi-region). Includes
+        ranged diagnostics intersecting the editable excerpt.
       - zeta-2: Zed's Zeta-2 model (SeedCoder-8B)
       - zeta: Zed's original Zeta model (Qwen2.5-Coder-7B, legacy)
       - copilot: GitHub Copilot completions
@@ -307,8 +309,8 @@ PROVIDER OPTIONS                                    *cursortab-config-provider*
       Sampling temperature for generation.
 
   `max_tokens`
-      Maximum tokens to generate. For sweep/zeta/zeta-2 providers, this also
-      determines the input context size (trimmed to fit within output budget).
+      Maximum tokens to generate. For sweep/zeta/zeta-2/zeta-2.1 providers,
+      this also determines the input context size when `context_size` is 0.
 
   `top_k`
       Top-k sampling parameter.

--- a/lua/cursortab/config.lua
+++ b/lua/cursortab/config.lua
@@ -136,7 +136,7 @@ local default_config = {
 	},
 
 	provider = {
-		type = "inline", -- "inline", "fim", "sweep", "zeta-2", "zeta", "copilot", "windsurf", or "mercuryapi"
+		type = "inline", -- "inline", "fim", "sweep", "zeta-2.1", "zeta-2", "zeta", "copilot", "windsurf", or "mercuryapi"
 		url = "http://localhost:8000", -- URL of the provider server
 		api_key_env = "", -- Environment variable name for API key (e.g., "OPENAI_API_KEY")
 		model = "", -- Model name
@@ -279,7 +279,17 @@ local function migrate_deprecated_config(user_config)
 end
 
 -- Valid values for enum-like config options
-local valid_provider_types = { inline = true, fim = true, sweep = true, ["zeta-2"] = true, zeta = true, copilot = true, windsurf = true, mercuryapi = true }
+local valid_provider_types = {
+	inline = true,
+	fim = true,
+	sweep = true,
+	["zeta-2.1"] = true,
+	["zeta-2"] = true,
+	zeta = true,
+	copilot = true,
+	windsurf = true,
+	mercuryapi = true,
+}
 local valid_log_levels = { trace = true, debug = true, info = true, warn = true, error = true }
 local valid_addition_styles = { dimmed = true, highlight = true }
 
@@ -319,7 +329,7 @@ local function validate_config(cfg)
 	if cfg.provider and cfg.provider.type then
 		if not valid_provider_types[cfg.provider.type] then
 			error(string.format(
-				"[cursortab.nvim] Invalid provider.type '%s'. Must be one of: inline, fim, sweep, zeta-2, zeta, copilot, windsurf, mercuryapi",
+				"[cursortab.nvim] Invalid provider.type '%s'. Must be one of: inline, fim, sweep, zeta-2.1, zeta-2, zeta, copilot, windsurf, mercuryapi",
 				cfg.provider.type
 			))
 		end

--- a/server/daemon.go
+++ b/server/daemon.go
@@ -98,6 +98,8 @@ func NewDaemon(config Config) (*Daemon, error) {
 		prov = zeta.NewProvider(providerConfig)
 	case types.ProviderTypeZeta2:
 		prov = zeta2.NewProvider(providerConfig)
+	case types.ProviderTypeZeta21:
+		prov = zeta2.NewProvider21(providerConfig)
 	case types.ProviderTypeCopilot:
 		prov = copilot.NewProvider(buf)
 	case types.ProviderTypeWindsurf:

--- a/server/eval/harness/factory.go
+++ b/server/eval/harness/factory.go
@@ -50,6 +50,10 @@ func BuildProviderForTarget(t Target, baseCfg *types.ProviderConfig, transport h
 		p := zeta2.NewProvider(cfg)
 		p.SetHTTPTransport(transport)
 		return p, nil
+	case "zeta-2.1":
+		p := zeta2.NewProvider21(cfg)
+		p.SetHTTPTransport(transport)
+		return p, nil
 	case "fim":
 		if cfg.ProviderContextSize == 0 {
 			cfg.ProviderContextSize = 1024

--- a/server/eval/harness/scenario.go
+++ b/server/eval/harness/scenario.go
@@ -80,7 +80,7 @@ type Scenario struct {
 // type can appear multiple times (e.g. sweep-v1 vs sweep-v2).
 type Target struct {
 	Name  string // "sweep-v1", "mercuryapi", etc.
-	Type  string // "mercuryapi", "zeta", "zeta-2"
+	Type  string // "mercuryapi", "zeta", "zeta-2", "zeta-2.1"
 	Model string // model version id
 	URL   string // provider endpoint; empty = default
 }

--- a/server/provider/zeta2/zeta21.go
+++ b/server/provider/zeta2/zeta21.go
@@ -1,0 +1,420 @@
+package zeta2
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"cursortab/client/openai"
+	sourcectx "cursortab/ctx"
+	"cursortab/engine"
+	"cursortab/provider"
+	"cursortab/text"
+	"cursortab/types"
+)
+
+const (
+	zeta21ProviderName = "zeta-2.1"
+	zeta21EOSMarker    = "<[end▁of▁sentence]>"
+)
+
+var zeta21StopTokens = []string{zeta21EOSMarker}
+
+type Provider21 struct {
+	provider.Base
+	provider.OpenAI
+}
+
+var _ engine.Provider = (*Provider21)(nil)
+var _ provider.CompletionFlow[*openai.CompletionRequest, *openai.CompletionResult] = (*Provider21)(nil)
+
+func NewProvider21(config *types.ProviderConfig) *Provider21 {
+	return &Provider21{
+		Base: provider.NewBase(engine.CompletionEdit, sourcectx.Materials{
+			sourcectx.Diagnostics{}, sourcectx.Treesitter{}, sourcectx.GitDiff{},
+			sourcectx.RecentFiles{}, sourcectx.EditHistory{},
+		}, provider.SyntheticPrefetchEnabled),
+		OpenAI: provider.NewOpenAI(zeta21ProviderName, config),
+	}
+}
+
+func (p *Provider21) Complete(ctx context.Context, input sourcectx.CompletionInput) (*types.CompletionResponse, error) {
+	return provider.StartBatch(ctx, input, p.ProviderConfig(), p)
+}
+
+func (p *Provider21) Build(ctx *provider.RequestState) (*openai.CompletionRequest, error) {
+	prompt := assembleZeta21Prompt(ctx)
+	req := p.Request(prompt, zeta21StopTokens)
+	p.LogRequest(req, ctx.Window.MaxLines)
+	return req, nil
+}
+
+func (p *Provider21) Parse(ctx *provider.RequestState, result *openai.CompletionResult) (*types.CompletionResponse, error) {
+	return parseZeta21Result(ctx, result), nil
+}
+
+// Zeta 2.1 uses the SeedCoder SPM envelope from Zeta-2 with V0318 numbered
+// boundaries inside one contiguous editable excerpt. The model returns the
+// two boundaries surrounding the smaller span it chose to rewrite.
+func assembleZeta21Prompt(ctx *provider.RequestState) string {
+	trimmed := ctx.Window.Lines
+	input := ctx.Input
+	current := input.Current
+	editableStart, editableEnd := computeEditableRange(trimmed, ctx.Window.CursorLine, ctx.Window.Start, treesitterRanges(input.Materials))
+
+	var b strings.Builder
+	b.WriteString(fimSuffix)
+	suffixText := ""
+	if editableEnd < len(trimmed) {
+		suffixText = strings.Join(trimmed[editableEnd:], "\n")
+		b.WriteString(suffixText)
+	}
+	ensureTrailingNewline(&b, suffixText)
+	b.WriteString(fimPrefix)
+
+	if recentFiles, ok := sourcectx.Find[sourcectx.RecentFiles](input.Materials); ok {
+		writeRecentFilesPseudoFiles(&b, recentFiles.Files)
+	}
+	if editHistoryMaterial, ok := sourcectx.Find[sourcectx.EditHistory](input.Materials); ok {
+		editHistory := buildEditHistory(editHistoryMaterial.Files)
+		if editHistory != "" {
+			writePseudoFile(&b, "edit_history", editHistory)
+		}
+	}
+	if treesitter, ok := sourcectx.Find[sourcectx.Treesitter](input.Materials); ok {
+		writeTreesitterPseudoFile(&b, treesitter.Data)
+	}
+	if gitDiff, ok := sourcectx.Find[sourcectx.GitDiff](input.Materials); ok {
+		writeGitDiffPseudoFile(&b, gitDiff.Data)
+	}
+	if diagnostics, ok := sourcectx.Find[sourcectx.Diagnostics](input.Materials); ok {
+		writeZeta21DiagnosticsPseudoFile(
+			&b,
+			diagnostics.Data,
+			ctx.Window.Start+editableStart+1,
+			ctx.Window.Start+editableEnd,
+		)
+	}
+
+	b.WriteString(fileMarker)
+	b.WriteString(current.File.Path)
+	b.WriteString("\n")
+	if editableStart > 0 {
+		b.WriteString(strings.Join(trimmed[:editableStart], "\n"))
+		b.WriteString("\n")
+	}
+
+	rendered := renderZeta21Editable(trimmed, editableStart, editableEnd, ctx.Window.CursorLine, current.Cursor.Col)
+	b.WriteString(rendered.text)
+	ensureTrailingNewline(&b, rendered.text)
+	b.WriteString(fimMiddle)
+	return b.String()
+}
+
+const (
+	zeta21MinBlockLines = 6
+	zeta21MaxBlockLines = 16
+	zeta21MaxNudgeLines = 5
+)
+
+func writeZeta21DiagnosticsPseudoFile(b *strings.Builder, diagnostics *types.Diagnostics, editableStartLine, editableEndLine int) {
+	if diagnostics == nil || editableStartLine > editableEndLine {
+		return
+	}
+
+	filtered := &types.Diagnostics{FilePath: diagnostics.FilePath}
+	for _, diagnostic := range diagnostics.Items {
+		if diagnostic == nil || diagnostic.Range == nil || diagnostic.Range.StartLine <= 0 {
+			continue
+		}
+
+		diagnosticEndLine := diagnostic.Range.EndLine
+		if diagnosticEndLine < diagnostic.Range.StartLine {
+			diagnosticEndLine = diagnostic.Range.StartLine
+		}
+		if diagnostic.Range.StartLine > editableEndLine || diagnosticEndLine < editableStartLine {
+			continue
+		}
+
+		filtered.Items = append(filtered.Items, diagnostic)
+	}
+
+	writeDiagnosticsPseudoFile(b, filtered)
+}
+
+type zeta21LineInfo struct {
+	startByte   int
+	isBlank     bool
+	isGoodStart bool
+}
+
+type renderedZeta21Editable struct {
+	text          string
+	boundaryLines []int
+}
+
+func zeta21MarkerBoundaryLines(ctx *provider.RequestState) []int {
+	start, end := computeEditableRange(ctx.Window.Lines, ctx.Window.CursorLine, ctx.Window.Start, treesitterRanges(ctx.Input.Materials))
+	rendered := renderZeta21Editable(ctx.Window.Lines, start, end, ctx.Window.CursorLine, ctx.Input.Current.Cursor.Col)
+	return rendered.boundaryLines
+}
+
+func renderZeta21Editable(lines []string, editableStart, editableEnd, cursorLine, cursorCol int) renderedZeta21Editable {
+	editableText := textForLineRange(lines, editableStart, editableEnd)
+	markerOffsets := computeZeta21MarkerOffsets(editableText)
+	lineInfo := collectZeta21LineInfo(editableText)
+	lineByStartByte := make(map[int]int, len(lineInfo))
+	for i, line := range lineInfo {
+		lineByStartByte[line.startByte] = i
+	}
+
+	boundaryLines := make([]int, len(markerOffsets))
+	for i, offset := range markerOffsets {
+		if offset == len(editableText) {
+			boundaryLines[i] = editableStart + len(lineInfo)
+			continue
+		}
+		boundaryLines[i] = editableStart + lineByStartByte[offset]
+	}
+
+	cursorOffset := relativeCursorByte(lines, editableStart, cursorLine, cursorCol)
+	cursorOffset = max(0, min(cursorOffset, len(editableText)))
+	var b strings.Builder
+	cursorPlaced := false
+	endsWithNewline := true
+	for i, offset := range markerOffsets {
+		if b.Len() > 0 && !endsWithNewline {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "<|marker_%d|>", i+1)
+		endsWithNewline = false
+
+		if i+1 >= len(markerOffsets) {
+			continue
+		}
+		nextOffset := markerOffsets[i+1]
+		b.WriteString("\n")
+		endsWithNewline = true
+		block := editableText[offset:nextOffset]
+		if !cursorPlaced && cursorOffset >= offset && cursorOffset <= nextOffset {
+			cursorPlaced = true
+			relativeOffset := cursorOffset - offset
+			b.WriteString(block[:relativeOffset])
+			b.WriteString(cursorMarker)
+			b.WriteString(block[relativeOffset:])
+			endsWithNewline = relativeOffset < len(block) && strings.HasSuffix(block, "\n")
+		} else {
+			b.WriteString(block)
+			if block != "" {
+				endsWithNewline = strings.HasSuffix(block, "\n")
+			}
+		}
+	}
+
+	return renderedZeta21Editable{text: b.String(), boundaryLines: boundaryLines}
+}
+
+func computeZeta21MarkerOffsets(editableText string) []int {
+	if editableText == "" {
+		return []int{0, 0}
+	}
+
+	lines := collectZeta21LineInfo(editableText)
+	offsets := []int{0}
+	lastBoundaryLine := 0
+	for i := 0; i < len(lines); {
+		gap := i - lastBoundaryLine
+		line := lines[i]
+		if gap >= zeta21MinBlockLines && !line.isBlank && i > 0 && lines[i-1].isBlank {
+			target := i
+			if !line.isGoodStart {
+				if goodStart, ok := skipToGoodZeta21Start(lines, i); ok {
+					target = goodStart
+				}
+			}
+			if len(lines)-target >= zeta21MinBlockLines && lines[target].startByte > offsets[len(offsets)-1] {
+				offsets = append(offsets, lines[target].startByte)
+				lastBoundaryLine = target
+				i = target + 1
+				continue
+			}
+		}
+
+		if gap >= zeta21MaxBlockLines {
+			target := i
+			if goodStart, ok := skipToGoodZeta21Start(lines, i); ok {
+				target = goodStart
+			}
+			if lines[target].startByte > offsets[len(offsets)-1] {
+				offsets = append(offsets, lines[target].startByte)
+				lastBoundaryLine = target
+				i = target + 1
+				continue
+			}
+		}
+		i++
+	}
+
+	if offsets[len(offsets)-1] != len(editableText) {
+		offsets = append(offsets, len(editableText))
+	}
+	return offsets
+}
+
+func collectZeta21LineInfo(text string) []zeta21LineInfo {
+	if text == "" {
+		return nil
+	}
+	parts := strings.Split(text, "\n")
+	if strings.HasSuffix(text, "\n") && len(parts) > 1 {
+		parts = parts[:len(parts)-1]
+	}
+	lines := make([]zeta21LineInfo, 0, len(parts))
+	startByte := 0
+	for _, line := range parts {
+		trimmed := strings.TrimSpace(line)
+		isBlank := trimmed == ""
+		lines = append(lines, zeta21LineInfo{
+			startByte:   startByte,
+			isBlank:     isBlank,
+			isGoodStart: !isBlank && !isZeta21StructuralTail(trimmed),
+		})
+		startByte += len(line) + 1
+	}
+	return lines
+}
+
+func skipToGoodZeta21Start(lines []zeta21LineInfo, from int) (int, bool) {
+	end := min(len(lines), from+zeta21MaxNudgeLines)
+	for i := from; i < end; i++ {
+		if lines[i].isGoodStart {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func isZeta21StructuralTail(line string) bool {
+	if strings.HasPrefix(line, "}") || strings.HasPrefix(line, "]") || strings.HasPrefix(line, ")") {
+		return true
+	}
+	line = strings.TrimSuffix(line, ";")
+	switch line {
+	case "break", "continue", "return", "throw", "end":
+		return true
+	default:
+		return false
+	}
+}
+
+func textForLineRange(lines []string, start, end int) string {
+	text := strings.Join(lines[start:end], "\n")
+	if end < len(lines) && !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
+	return text
+}
+
+func relativeCursorByte(lines []string, startLine, cursorLine, cursorCol int) int {
+	offset := 0
+	for i := startLine; i < cursorLine && i < len(lines); i++ {
+		offset += len(lines[i]) + 1
+	}
+	return offset + cursorCol
+}
+
+var zeta21NumberedMarkerPattern = regexp.MustCompile(`<\|marker_(\d+)\|>`)
+
+type zeta21MarkerHit struct {
+	number int
+	start  int
+	end    int
+}
+
+type zeta21MarkerSpan struct {
+	replacement string
+	startLine   int
+	endLine     int
+	noEdits     bool
+}
+
+func parseZeta21Result(ctx *provider.RequestState, result *openai.CompletionResult) *types.CompletionResponse {
+	if result.FinishReason == "length" || result.StoppedEarly {
+		return provider.EmptyResponse()
+	}
+
+	span, ok := decodeZeta21MarkerSpan(ctx, result.Text)
+	if !ok || span.noEdits {
+		return provider.EmptyResponse()
+	}
+	replacement := span.replacement
+	if eos := strings.Index(replacement, zeta21EOSMarker); eos >= 0 {
+		replacement = replacement[:eos]
+	}
+	if stripped, resp, done := provider.StripRepetitionText(replacement); done {
+		return resp
+	} else {
+		replacement = stripped
+	}
+
+	cursorMarkerLine, cursorMarkerSeen := cursorMarkerPosition(replacement)
+	replacement = stripCursorMarker(replacement, cursorMarker)
+	newLines := text.SplitLines(replacement)
+	resp := provider.BuildCompletion(ctx, ctx.Window.Start+span.startLine+1, ctx.Window.Start+span.endLine, newLines)
+	if resp.Completion != nil && cursorMarkerSeen {
+		resp.CursorTarget = buildCursorTarget(ctx, span.startLine, cursorMarkerLine, newLines)
+	}
+	return resp
+}
+
+func decodeZeta21MarkerSpan(ctx *provider.RequestState, output string) (zeta21MarkerSpan, bool) {
+	matches := zeta21NumberedMarkerPattern.FindAllStringSubmatchIndex(output, -1)
+	if len(matches) != 2 {
+		return zeta21MarkerSpan{}, false
+	}
+
+	hits := make([]zeta21MarkerHit, 0, len(matches))
+	for _, match := range matches {
+		number, err := strconv.Atoi(output[match[2]:match[3]])
+		if err != nil || number < 1 {
+			return zeta21MarkerSpan{}, false
+		}
+		hits = append(hits, zeta21MarkerHit{number: number, start: match[0], end: match[1]})
+	}
+	if hits[1].number < hits[0].number {
+		return zeta21MarkerSpan{}, false
+	}
+
+	boundaries := zeta21MarkerBoundaryLines(ctx)
+	startMarkerIndex := hits[0].number - 1
+	endMarkerIndex := hits[1].number - 1
+	if startMarkerIndex >= len(boundaries) || endMarkerIndex >= len(boundaries) {
+		return zeta21MarkerSpan{}, false
+	}
+	startLine := boundaries[startMarkerIndex]
+	endLine := boundaries[endMarkerIndex]
+	if endLine < startLine {
+		return zeta21MarkerSpan{}, false
+	}
+
+	replacement := output[hits[0].end:hits[1].start]
+	if hits[0].number == hits[1].number {
+		if strings.TrimSpace(replacement) != "" {
+			return zeta21MarkerSpan{}, false
+		}
+		return zeta21MarkerSpan{startLine: startLine, endLine: endLine, noEdits: true}, true
+	}
+	if strings.HasPrefix(replacement, "\r\n") {
+		replacement = strings.TrimPrefix(replacement, "\r\n")
+	} else {
+		replacement = strings.TrimPrefix(replacement, "\n")
+	}
+	if strings.HasSuffix(replacement, "\r\n") {
+		replacement = strings.TrimSuffix(replacement, "\r\n")
+	} else {
+		replacement = strings.TrimSuffix(replacement, "\n")
+	}
+	return zeta21MarkerSpan{replacement: replacement, startLine: startLine, endLine: endLine}, true
+}

--- a/server/provider/zeta2/zeta21_test.go
+++ b/server/provider/zeta2/zeta21_test.go
@@ -1,0 +1,332 @@
+package zeta2
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"cursortab/assert"
+	"cursortab/client/openai"
+	sourcectx "cursortab/ctx"
+	"cursortab/engine"
+	"cursortab/provider"
+	"cursortab/types"
+)
+
+func newZeta21TestProvider() *Provider21 {
+	return NewProvider21(&types.ProviderConfig{
+		ProviderModel:     "zeta-2.1",
+		ProviderMaxTokens: 2048,
+	})
+}
+
+func TestZeta21Build_UsesNumberedRegionProtocol(t *testing.T) {
+	p := newZeta21TestProvider()
+	ctx := stateForLines("main.go", []string{
+		"package main",
+		"",
+		"func main() {",
+		"\tprintln(\"hello\")",
+		"}",
+	}, 4, 10)
+
+	req, err := p.Build(ctx)
+	assert.Equal(t, nil, err, "build should succeed")
+	assert.Equal(t, []string{zeta21EOSMarker}, req.Stop, "uses the model EOS stop token")
+	assert.True(t, strings.Contains(req.Prompt, "<|marker_1|>\n"), "contains opening numbered boundary")
+	assert.True(t, strings.Contains(req.Prompt, "<|marker_2|>\n"), "contains closing numbered boundary")
+	assert.True(t, strings.Contains(req.Prompt, "println(\""+cursorMarker+"hello\")"), "places the cursor inside the editable excerpt")
+	assert.False(t, strings.Contains(req.Prompt, currentMarker), "does not use Zeta-2 CURRENT scaffolding")
+	assert.False(t, strings.Contains(req.Prompt, separator), "does not use Zeta-2 separator scaffolding")
+	assert.True(t, strings.HasSuffix(req.Prompt, fimMiddle), "ends with fim-middle")
+}
+
+func TestZeta21Build_V0318BoundariesSplitLongEditableExcerpt(t *testing.T) {
+	p := newZeta21TestProvider()
+	lines := make([]string, 40)
+	for i := range lines {
+		lines[i] = "line " + strings.Repeat("x", i%3)
+	}
+	ctx := stateForLines("main.go", lines, 20, 0)
+
+	req, err := p.Build(ctx)
+	assert.Equal(t, nil, err, "build should succeed")
+	boundaries := zeta21MarkerBoundaryLines(ctx)
+
+	assert.Equal(t, []int{4, 20, 35}, boundaries, "hard cap creates deterministic line boundaries")
+	assert.True(t, strings.Contains(req.Prompt, "<|marker_3|>"), "renders every computed boundary")
+	assert.False(t, strings.Contains(req.Prompt, "<|marker_4|>"), "does not render an extra boundary")
+}
+
+func TestZeta21Build_PrefersBlankLineBoundary(t *testing.T) {
+	lines := make([]string, 31)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line %d", i)
+	}
+	lines[7] = ""
+	ctx := stateForLines("main.go", lines, 16, 0)
+
+	boundaries := zeta21MarkerBoundaryLines(ctx)
+
+	assert.GreaterOrEqual(t, len(boundaries), 3, "blank-line excerpt has multiple boundaries")
+	if len(boundaries) < 3 {
+		return
+	}
+	assert.Equal(t, 0, boundaries[0], "editable excerpt starts at the first line")
+	assert.Equal(t, 8, boundaries[1], "new block starts after the blank line")
+	assert.Equal(t, 31, boundaries[len(boundaries)-1], "last boundary ends the editable excerpt")
+}
+
+func TestZeta21Build_PreservesUTF8CursorByteOffset(t *testing.T) {
+	p := newZeta21TestProvider()
+	ctx := stateForLines("main.go", []string{"яcursor"}, 1, 2)
+
+	req, err := p.Build(ctx)
+	assert.Equal(t, nil, err, "build should succeed")
+	assert.True(t, strings.Contains(req.Prompt, "я"+cursorMarker+"cursor"), "cursor byte offset remains on a UTF-8 boundary")
+}
+
+func TestZeta21Build_EmptyBufferHasInsertionBoundaries(t *testing.T) {
+	p := newZeta21TestProvider()
+	ctx := stateForLines("main.go", nil, 1, 0)
+
+	req, err := p.Build(ctx)
+	assert.Equal(t, nil, err, "build should succeed")
+	assert.True(t, strings.Contains(req.Prompt, "<|marker_1|>\n"+cursorMarker+"\n<|marker_2|>"), "empty buffer exposes a zero-width editable span")
+}
+
+func TestZeta21Build_IncludesOnlyDiagnosticsIntersectingEditableExcerpt(t *testing.T) {
+	p := newZeta21TestProvider()
+	lines := make([]string, 60)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line %d", i+1)
+	}
+	diagnostics := &types.Diagnostics{Items: []*types.Diagnostic{
+		{Severity: types.SeverityError, Message: "before excerpt", Range: &types.CursorRange{StartLine: 14, EndLine: 14}},
+		{Severity: types.SeverityError, Message: "overlaps excerpt start", Range: &types.CursorRange{StartLine: 14, EndLine: 15}},
+		{Severity: types.SeverityError, Message: "inside excerpt", Range: &types.CursorRange{StartLine: 30}},
+		{Severity: types.SeverityError, Message: "overlaps excerpt end", Range: &types.CursorRange{StartLine: 45, EndLine: 46}},
+		{Severity: types.SeverityError, Message: "after excerpt", Range: &types.CursorRange{StartLine: 46, EndLine: 46}},
+		{Severity: types.SeverityError, Message: "without location"},
+	}}
+	ctx := stateForLines("main.go", lines, 30, 0, sourcectx.Materials{
+		sourcectx.Diagnostics{Data: diagnostics},
+	})
+
+	req, err := p.Build(ctx)
+	assert.Equal(t, nil, err, "build should succeed")
+	assert.False(t, strings.Contains(req.Prompt, "before excerpt"), "diagnostic before editable excerpt is omitted")
+	assert.True(t, strings.Contains(req.Prompt, "overlaps excerpt start"), "diagnostic overlapping excerpt start is included")
+	assert.True(t, strings.Contains(req.Prompt, "inside excerpt"), "diagnostic inside editable excerpt is included")
+	assert.True(t, strings.Contains(req.Prompt, "overlaps excerpt end"), "diagnostic overlapping excerpt end is included")
+	assert.False(t, strings.Contains(req.Prompt, "after excerpt"), "diagnostic after editable excerpt is omitted")
+	assert.False(t, strings.Contains(req.Prompt, "without location"), "diagnostic without a range is omitted")
+}
+
+func TestZeta21Build_IncludesAllDiagnosticsInEditableExcerpt(t *testing.T) {
+	p := newZeta21TestProvider()
+	lines := make([]string, 40)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line %d", i+1)
+	}
+	diagnostics := &types.Diagnostics{}
+	for i := range 20 {
+		diagnostics.Items = append(diagnostics.Items, &types.Diagnostic{
+			Severity: types.SeverityWarning,
+			Message:  fmt.Sprintf("diagnostic-%03d-end", i),
+			Source:   "test",
+			Range:    &types.CursorRange{StartLine: 20},
+		})
+	}
+	ctx := stateForLines("main.go", lines, 20, 0, sourcectx.Materials{
+		sourcectx.Diagnostics{Data: diagnostics},
+	})
+
+	req, err := p.Build(ctx)
+	assert.Equal(t, nil, err, "build should succeed")
+	assert.Equal(t, 20, strings.Count(req.Prompt, "(source: test)"), "all diagnostics in the editable excerpt are included")
+	assert.True(t, strings.Contains(req.Prompt, "diagnostic-019-end"), "last matching diagnostic is included")
+}
+
+func TestZeta21Build_MapsDiagnosticFilterThroughTrimmedWindow(t *testing.T) {
+	p := newZeta21TestProvider()
+	lines := make([]string, 100)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line %d", i+1)
+	}
+	diagnostics := &types.Diagnostics{Items: []*types.Diagnostic{
+		{Severity: types.SeverityError, Message: "before trimmed excerpt", Range: &types.CursorRange{StartLine: 34}},
+		{Severity: types.SeverityError, Message: "at trimmed excerpt start", Range: &types.CursorRange{StartLine: 35}},
+		{Severity: types.SeverityError, Message: "at trimmed excerpt end", Range: &types.CursorRange{StartLine: 65}},
+		{Severity: types.SeverityError, Message: "after trimmed excerpt", Range: &types.CursorRange{StartLine: 66}},
+	}}
+	ctx := stateForLines("main.go", lines, 50, 0, sourcectx.Materials{
+		sourcectx.Diagnostics{Data: diagnostics},
+	})
+	ctx.Window = provider.RequestWindow{
+		Lines:      lines[20:80],
+		Start:      20,
+		CursorLine: 29,
+	}
+
+	req, err := p.Build(ctx)
+	assert.Equal(t, nil, err, "build should succeed")
+	assert.False(t, strings.Contains(req.Prompt, "before trimmed excerpt"), "diagnostic before document-relative excerpt is omitted")
+	assert.True(t, strings.Contains(req.Prompt, "at trimmed excerpt start"), "document-relative excerpt start is included")
+	assert.True(t, strings.Contains(req.Prompt, "at trimmed excerpt end"), "document-relative excerpt end is included")
+	assert.False(t, strings.Contains(req.Prompt, "after trimmed excerpt"), "diagnostic after document-relative excerpt is omitted")
+}
+
+func TestZeta21Parse_MapsNumberedSpanToDocumentLines(t *testing.T) {
+	p := newZeta21TestProvider()
+	lines := make([]string, 40)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line %d", i)
+	}
+	lines[20] = "old value"
+	ctx := stateForLines("main.go", lines, 20, 0)
+	replacement := append([]string(nil), lines[20:35]...)
+	replacement[0] = "new value"
+	result := &openai.CompletionResult{
+		Text: "<|marker_2|>\n" + strings.Join(replacement, "\n") + "\n<|marker_3|>" + zeta21EOSMarker,
+	}
+
+	resp, err := p.Parse(ctx, result)
+	assert.Equal(t, nil, err, "parse should succeed")
+	assert.True(t, resp.Completion != nil, "has a completion")
+	if resp.Completion == nil {
+		return
+	}
+	assert.Equal(t, 21, resp.Completion.StartLine, "starts at marker_2 boundary")
+	assert.Equal(t, 35, resp.Completion.EndLineInc, "ends before marker_3 boundary")
+	assert.Equal(t, replacement, resp.Completion.Lines, "uses only text inside the marker span")
+}
+
+func TestZeta21Parse_RejectsUnsafeMarkerSpans(t *testing.T) {
+	p := newZeta21TestProvider()
+	ctx := stateForLines("main.go", []string{"a", "b", "c"}, 2, 0)
+
+	for _, output := range []string{
+		"changed",
+		"<|marker_1|>\nchanged",
+		"<|marker_2|>\nchanged\n<|marker_1|>",
+		"<|marker_1|>changed<|marker_1|>",
+		"<|marker_1|>\na\n<|marker_2|>\nb\n<|marker_3|>",
+		"<|marker_9|>\nchanged\n<|marker_10|>",
+	} {
+		resp, err := p.Parse(ctx, &openai.CompletionResult{Text: output})
+		assert.Equal(t, nil, err, "parse should not return an error")
+		assert.True(t, resp.Completion == nil, "malformed marker span is rejected")
+	}
+}
+
+func TestZeta21Parse_RecognizesRepeatedMarkerAsNoEdits(t *testing.T) {
+	p := newZeta21TestProvider()
+	ctx := stateForLines("main.go", []string{"first", "second", "third"}, 2, 0)
+	output := "<|marker_1|><|marker_1|>"
+
+	span, ok := decodeZeta21MarkerSpan(ctx, output)
+	assert.True(t, ok, "repeated marker is a valid protocol response")
+	assert.True(t, span.noEdits, "repeated marker represents NO_EDITS")
+
+	resp, err := p.Parse(ctx, &openai.CompletionResult{Text: output})
+	assert.Equal(t, nil, err, "parse should succeed")
+	assert.True(t, resp.Completion == nil, "NO_EDITS has no completion")
+	assert.True(t, resp.CursorTarget == nil, "NO_EDITS has no cursor target")
+}
+
+func TestZeta21Parse_AppliesTrimmedWindowOffset(t *testing.T) {
+	p := newZeta21TestProvider()
+	lines := make([]string, 60)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line %d", i)
+	}
+	input := testInput("main.go", lines, 30, 0)
+	ctx := stateForInput(input, nil)
+	ctx.Window = provider.RequestWindow{
+		Lines:      lines[10:50],
+		Start:      10,
+		CursorLine: 19,
+	}
+	replacement := append([]string(nil), lines[30:45]...)
+	replacement[0] = "changed"
+
+	resp, err := p.Parse(ctx, &openai.CompletionResult{
+		Text: "<|marker_2|>\n" + strings.Join(replacement, "\n") + "\n<|marker_3|>",
+	})
+	assert.Equal(t, nil, err, "parse should succeed")
+	assert.True(t, resp.Completion != nil, "has a completion")
+	if resp.Completion == nil {
+		return
+	}
+	assert.Equal(t, 31, resp.Completion.StartLine, "start includes the trimmed window offset")
+	assert.Equal(t, 45, resp.Completion.EndLineInc, "end includes the trimmed window offset")
+}
+
+func TestZeta21Parse_PreservesDeletionOnlyEdit(t *testing.T) {
+	p := newZeta21TestProvider()
+	ctx := stateForLines("main.go", []string{"obsolete()"}, 1, 0)
+
+	resp, err := p.Parse(ctx, &openai.CompletionResult{Text: "<|marker_1|>\n<|marker_2|>"})
+	assert.Equal(t, nil, err, "parse should succeed")
+	assert.True(t, resp.Completion != nil, "deletion is a completion")
+	if resp.Completion == nil {
+		return
+	}
+	assert.Equal(t, 1, resp.Completion.StartLine, "deletion starts at first boundary")
+	assert.Equal(t, 1, resp.Completion.EndLineInc, "deletion ends at second boundary")
+	assert.Equal(t, []string{}, resp.Completion.Lines, "replacement is empty")
+}
+
+func TestZeta21Parse_PreservesInsertionOnlyEdit(t *testing.T) {
+	p := newZeta21TestProvider()
+	ctx := stateForLines("main.go", nil, 1, 0)
+
+	resp, err := p.Parse(ctx, &openai.CompletionResult{Text: "<|marker_1|>\ninserted()\n<|marker_2|>"})
+	assert.Equal(t, nil, err, "parse should succeed")
+	assert.True(t, resp.Completion != nil, "insertion is a completion")
+	if resp.Completion == nil {
+		return
+	}
+	assert.Equal(t, 1, resp.Completion.StartLine, "insertion starts at the first line")
+	assert.Equal(t, 0, resp.Completion.EndLineInc, "zero-width span replaces no existing line")
+	assert.Equal(t, []string{"inserted()"}, resp.Completion.Lines, "inserted content is preserved")
+}
+
+func TestZeta21Parse_MapsCursorMarkerInsideSelectedSpan(t *testing.T) {
+	p := newZeta21TestProvider()
+	ctx := stateForLines("main.go", []string{"first", "old", "last"}, 2, 0)
+
+	resp, err := p.Parse(ctx, &openai.CompletionResult{
+		Text: "<|marker_1|>\nfirst\nnew" + cursorMarker + "\nlast\n<|marker_2|>",
+	})
+	assert.Equal(t, nil, err, "parse should succeed")
+	assert.True(t, resp.Completion != nil, "has a completion")
+	assert.True(t, resp.CursorTarget != nil, "has a cursor target")
+	if resp.Completion == nil || resp.CursorTarget == nil {
+		return
+	}
+	assert.Equal(t, []string{"first", "new", "last"}, resp.Completion.Lines, "cursor marker is removed from code")
+	assert.Equal(t, int32(2), resp.CursorTarget.LineNumber, "cursor target maps to the output line")
+}
+
+func TestZeta21Parse_RejectsTruncatedGeneration(t *testing.T) {
+	p := newZeta21TestProvider()
+	ctx := stateForLines("main.go", []string{"old"}, 1, 0)
+
+	resp, err := p.Parse(ctx, &openai.CompletionResult{
+		Text:         "<|marker_1|>\nnew\n<|marker_2|>",
+		FinishReason: "length",
+	})
+	assert.Equal(t, nil, err, "parse should not return an error")
+	assert.True(t, resp.Completion == nil, "truncated generation is rejected")
+}
+
+func TestZeta21Complete_ImplementsBatchFlow(t *testing.T) {
+	var _ provider.CompletionFlow[*openai.CompletionRequest, *openai.CompletionResult] = newZeta21TestProvider()
+}
+
+func TestZeta21Complete_DoesNotImplementStreaming(t *testing.T) {
+	_, streams := any(newZeta21TestProvider()).(engine.StreamingProvider)
+	assert.False(t, streams, "Zeta 2.1 uses only the batch completion flow")
+}

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -183,6 +183,7 @@ const (
 	ProviderTypeSweep      ProviderType = "sweep"
 	ProviderTypeZeta       ProviderType = "zeta"
 	ProviderTypeZeta2      ProviderType = "zeta-2"
+	ProviderTypeZeta21     ProviderType = "zeta-2.1"
 	ProviderTypeCopilot    ProviderType = "copilot"
 	ProviderTypeMercuryAPI ProviderType = "mercuryapi"
 	ProviderTypeWindsurf   ProviderType = "windsurf"


### PR DESCRIPTION
Zeta 2.1 can still work with the old prompt format, but the [new format](https://zed.dev/blog/zeta2-1) is more efficient. It splits the input into small regions of roughly six lines, so the model can return just the regions that need changes—or an empty region when no edits are needed (just 14 tokens - this response is very fast).